### PR TITLE
No-ticket: hide user link on a task for non ROLE_ADMIN users

### DIFF
--- a/app/Resources/views/task/list.html.twig
+++ b/app/Resources/views/task/list.html.twig
@@ -17,9 +17,13 @@
                     <span class="pull-right">
                         Auteur :
                         {% if task.user %}
-                            <a href="{{ path('user_edit', {'id' : task.user.id}) }}">
+                            {% if is_granted('ROLE_ADMIN') %}
+                                <a href="{{ path('user_edit', {'id' : task.user.id}) }}">
+                                    {{ task.user.username }}
+                                </a>
+                            {% else %}
                                 {{ task.user.username }}
-                            </a>
+                            {% endif %}
                         {% else %}
                             anonyme
                         {% endif %}


### PR DESCRIPTION
No longer displays a clickable link to the creator edit page when the logged user is not a ROLE_ADMIN user.